### PR TITLE
Center main outlet

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -38,7 +38,7 @@ $sidebar-width: #{$sidebar_width}em;
   --spacer-width: minmax(var(--d-main-content-gap), 1fr);
   --main-outlet-width: minmax(0, var(--d-max-width));
   display: grid;
-  grid-template-areas: "spacer-left main spacer-right";
+  grid-template-areas: "spacer-left content spacer-right";
   grid-template-columns: var(--spacer-width) var(--main-outlet-width) var(
       --spacer-width
     );
@@ -46,7 +46,7 @@ $sidebar-width: #{$sidebar_width}em;
   padding: 0;
 
   body.has-sidebar-page & {
-    grid-template-areas: "sidebar spacer-left main spacer-right";
+    grid-template-areas: "sidebar spacer-left content spacer-right";
     grid-template-columns:
       var(--d-sidebar-width) var(--spacer-width) var(--main-outlet-width)
       var(--spacer-width);
@@ -67,7 +67,7 @@ $sidebar-width: #{$sidebar_width}em;
   }
 
   #main-outlet {
-    grid-area: main;
+    grid-area: content;
     margin: 0 auto;
     max-width: var(--d-max-width);
     width: 100%;

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -62,12 +62,10 @@ $sidebar-width: #{$sidebar_width}em;
   }
 
   .sidebar-wrapper {
-    grid-area: sidebar;
     width: 100%; // safari has issues without this
   }
 
   #main-outlet {
-    grid-area: content;
     margin: 0 auto;
     max-width: var(--d-max-width);
     width: 100%;

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -58,7 +58,8 @@ $sidebar-width: #{$sidebar_width}em;
   }
 
   body.has-full-page-chat & {
-    grid-template-columns: min-content;
+    --spacer-width: 0;
+    --d-max-width: 100%;
   }
 
   .sidebar-wrapper {

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -38,15 +38,16 @@ $sidebar-width: #{$sidebar_width}em;
   --spacer-width: minmax(var(--d-main-content-gap), 1fr);
   --main-outlet-width: minmax(0, var(--d-max-width));
   display: grid;
-  grid-template-areas: "spacer-left content spacer-right";
-  grid-template-columns: var(--spacer-width) var(--main-outlet-width) var(
+  grid-template-areas:
+    "sidebar spacer-left content spacer-right"
+    "sidebar spacer-left below-content spacer-right";
+  grid-template-columns: 0 var(--spacer-width) var(--main-outlet-width) var(
       --spacer-width
     );
   gap: 0;
   padding: 0;
 
   body.has-sidebar-page & {
-    grid-template-areas: "sidebar spacer-left content spacer-right";
     grid-template-columns:
       var(--d-sidebar-width) var(--spacer-width) var(--main-outlet-width)
       var(--spacer-width);

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -35,12 +35,22 @@ $sidebar-width: #{$sidebar_width}em;
 }
 
 #main-outlet-wrapper {
-  grid-template-columns: 1fr minmax(0, var(--d-max-width)) 1fr;
-  gap: 2em;
+  --spacer-width: minmax(var(--d-main-content-gap), 1fr);
+  --main-outlet-width: minmax(0, var(--d-max-width));
+  display: grid;
+  grid-template-areas: "spacer-left main spacer-right";
+  grid-template-columns: var(--spacer-width) var(--main-outlet-width) var(
+      --spacer-width
+    );
+  gap: 0;
   padding: 0;
 
   body.has-sidebar-page & {
-    grid-template-columns: 1fr minmax(0, var(--d-max-width)) 1fr; // overriding core
+    grid-template-areas: "sidebar spacer-left main spacer-right";
+    grid-template-columns:
+      var(--d-sidebar-width) var(--spacer-width) var(--main-outlet-width)
+      var(--spacer-width);
+    gap: 0;
 
     .sidebar-wrapper {
       width: var(--d-sidebar-width);
@@ -49,14 +59,15 @@ $sidebar-width: #{$sidebar_width}em;
 
   body.has-full-page-chat & {
     grid-template-columns: min-content;
-    gap: 0;
   }
 
   .sidebar-wrapper {
+    grid-area: sidebar;
     width: 100%; // safari has issues without this
   }
 
   #main-outlet {
+    grid-area: main;
     margin: 0 auto;
     max-width: var(--d-max-width);
     width: 100%;


### PR DESCRIPTION
Adds two named grid columns to always center the main-outlet.

Applies width of --d-main-content-gap directly to the spacer columns. Before the gap was applied as grid gap, but that would result in two gaps applied around the left spacer when the sidebar is visible.

Before:

<img width="1818" height="360" alt="Screenshot From 2026-03-31 12-36-57" src="https://github.com/user-attachments/assets/b989575f-f0cd-413c-9a49-358bd9c1c3c4" />

After:

<img width="1818" height="360" alt="image" src="https://github.com/user-attachments/assets/f30b0781-53e8-4f6f-bf8a-90dc1c1f2117" />



