### PR TITLE
FIX: Prevent layout shift when toggling the sidebar

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -3,6 +3,11 @@
 $sidebar-width: #{$sidebar_width}em;
 
 @include viewport.from(md) {
+  .wrap,
+  body.has-sidebar-page .wrap {
+    max-width: unset; // undo core default
+  }
+
   #main-outlet-wrapper {
     grid-template-columns: minmax(0, 1fr);
     gap: 2em;
@@ -111,39 +116,6 @@ $sidebar-width: #{$sidebar_width}em;
         .title {
           min-width: auto;
         }
-
-        .has-sidebar-page & {
-          // at wide widths, when 1fr > 0
-          // we want the panel to be the same width as the sidebar
-          // this way we can get more accurate centering
-          grid-template-columns:
-            calc(var(--d-sidebar-width) - 11px) // 11px is wrap padding
-            1fr
-            minmax(0, calc(var(--d-max-width)))
-            1fr
-            auto;
-          gap: 1em;
-
-          // at narrower widths, when 1fr = 0
-          // we can center without matching the sidebar's width
-          // which allows the title to take up the remaining width
-          @media (width <= 1400px) {
-            grid-template-columns:
-              calc(var(--d-sidebar-width) - 11px)
-              1fr
-              minmax(0, calc(var(--d-max-width)))
-              1fr
-              auto;
-          }
-
-          @media (width <= 1000px) {
-            gap: 0.5em;
-          }
-
-          .d-header-mode {
-            grid-area: extra-info;
-          }
-        }
       }
     }
 
@@ -204,10 +176,6 @@ $sidebar-width: #{$sidebar_width}em;
 
   // composer positioning
   body.has-sidebar-page {
-    .wrap {
-      max-width: unset; // undoing core default
-    }
-
     @media (width >= calc($reply-area-max-width + ($sidebar-width * 2))) {
       #reply-control.show-preview {
         margin-left: auto;

--- a/common/common.scss
+++ b/common/common.scss
@@ -10,7 +10,7 @@ $sidebar-width: #{$sidebar_width}em;
 
   #main-outlet-wrapper {
     grid-template-columns: minmax(0, 1fr);
-    gap: 2em;
+    gap: var(--d-wrap-padding-x);
     padding: 0;
 
     .sidebar-wrapper {

--- a/common/common.scss
+++ b/common/common.scss
@@ -102,20 +102,15 @@ $sidebar-width: #{$sidebar_width}em;
         display: grid;
         grid-template-areas: "logo lspace extra-info rspace panel";
         grid-template-columns:
-          minmax(auto, 1fr)
-          auto
+          calc(var(--d-sidebar-width) - var(--d-header-padding-x))
+          1fr
           minmax(0, calc(var(--d-max-width)))
-          auto
-          minmax(auto, 1fr);
+          1fr
+          auto;
+      }
 
-        .d-header-mode {
-          grid-area: extra-info;
-          white-space: nowrap;
-        }
-
-        .title {
-          min-width: auto;
-        }
+      .title {
+        min-width: auto;
       }
     }
 


### PR DESCRIPTION
Restore the global `max-width: unset` overrides that #69 dropped, so the header and content no longer re-center when the sidebar is hidden. 

Also unify the header `.contents` grid to one symmetric template so the search input stops shifting on toggle.