### PR TITLE
UX: add a setting to disable logo changes (#71)

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -68,6 +68,13 @@ $sidebar-width: #{$sidebar_width}em;
       }
     }
 
+    @if $use_default_logo_behavior == "true" {
+      // the small logo isn't constrained by the logo grid track
+      .title--minimized #site-logo {
+        max-width: unset;
+      }
+    }
+
     #site-text-logo {
       font-size: clamp(var(--font-0), 2.5vw, var(--font-up-2));
 
@@ -107,6 +114,18 @@ $sidebar-width: #{$sidebar_width}em;
           minmax(0, calc(var(--d-max-width)))
           1fr
           auto;
+
+        @if $use_default_logo_behavior == "true" {
+          // the small logo doesn't need the space reserved for the full logo
+          &:has(.title--minimized) {
+            grid-template-columns:
+              auto
+              1fr
+              minmax(0, calc(var(--d-max-width)))
+              1fr
+              auto;
+          }
+        }
       }
 
       .title {

--- a/javascripts/discourse/api-initializers/full-width.gjs
+++ b/javascripts/discourse/api-initializers/full-width.gjs
@@ -5,6 +5,11 @@ import { apiInitializer } from "discourse/lib/api";
 export default apiInitializer((api) => {
   document.body.classList.add("full-width-enabled");
 
+  // Leave the logo alone when the site's default behavior is preferred.
+  if (settings.use_default_logo_behavior) {
+    return;
+  }
+
   // When the sidebar is visible, force the HomeLogo to be in an 'un-minimized' state.
   const transformerExists = api.registerValueTransformer?.(
     "home-logo-minimized",

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,6 @@
 en:
   theme_metadata:
     description: "Makes Discourse occupy the full browser width"
+    settings:
+      use_default_logo_behavior:
+        description: "When enabled, the logo follows Discourse's default behavior and switches to the small logo when scrolling within a topic, even when the sidebar is visible."

--- a/settings.yml
+++ b/settings.yml
@@ -2,3 +2,7 @@ sidebar_width:
   type: integer
   default: 17
   description: Change this in case of custom sidebar width. Value in EM only.
+
+use_default_logo_behavior:
+  type: bool
+  default: false

--- a/spec/system/full_width_spec.rb
+++ b/spec/system/full_width_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe "Full width component", system: true do
     expect(page).to have_selector("#site-logo.logo-big")
   end
 
+  it "should use the small logo when scrolling down a topic if use_default_logo_behavior is enabled" do
+    theme.update_setting(:use_default_logo_behavior, true)
+    theme.save!
+
+    visit topic.relative_url
+
+    expect(page).to have_selector("#site-logo.logo-big")
+    expect(page).not_to have_selector(".d-header h1.header-title")
+
+    page.execute_script <<~JS
+      document.querySelector("#post_10").scrollIntoView(true);
+    JS
+
+    expect(page).to have_selector(".d-header h1.header-title")
+    expect(page).to have_selector("#site-logo.logo-small")
+  end
+
   it "should use default behavior when scrolling down a topic with no sidebar" do
     visit topic.relative_url
 


### PR DESCRIPTION
all the changes are gated by a new disabled setting, so safe to backport for someone who wants to use it on this release 